### PR TITLE
Adds batched document creation.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -24,10 +24,10 @@ Client.prototype = {
         'User-Agent': this.userAgent
       }
     }, function(error, response, body) {
-      var responseError = !(response.statusCode.toString().match(/2[\d]{2}/));
-
-      if (error || responseError)
-        return callback(error || response.body);
+      if (error)
+        return callback(error)
+      else if (!(response.statusCode.toString().match(/2[\d]{2}/)))
+        return callback(SON.parse(response.body))
       else
         return callback(null, JSON.parse(response.body))
     })
@@ -49,6 +49,8 @@ Client.prototype = {
     }, function(error, response, body) {
       if (error)
         return callback(error)
+      else if (!(response.statusCode.toString().match(/2[\d]{2}/)))
+        return callback(response.body)
       else
         return callback(null, response.body)
     })
@@ -70,6 +72,8 @@ Client.prototype = {
     }, function(error, response, body) {
       if (error)
         return callback(error)
+      else if (!(response.statusCode.toString().match(/2[\d]{2}/)))
+        return callback(response.body)
       else
         return callback(null, response.body)
     })
@@ -91,6 +95,8 @@ Client.prototype = {
     }, function(error, response, body) {
       if (error)
         return callback(error)
+      else if (!(response.statusCode.toString().match(/2[\d]{2}/)))
+        return callback(response)
       else
         return callback(null, response)
     })

--- a/lib/client.js
+++ b/lib/client.js
@@ -24,8 +24,10 @@ Client.prototype = {
         'User-Agent': this.userAgent
       }
     }, function(error, response, body) {
-      if (error)
-        return callback(error)
+      var responseError = !(response.statusCode.toString().match(/2[\d]{2}/));
+
+      if (error || responseError)
+        return callback(error || response.body);
       else
         return callback(null, JSON.parse(response.body))
     })

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -1,11 +1,13 @@
 'use strict';
 
+var async = require('async')
+
 var Documents = function(client) {
   this.client = client
 }
 
 Documents.prototype = {
-  
+
   list: function(params, callback) {
     this.client.get('/engines/{engine}/document_types/{documentType}/documents.json', params, callback)
   },
@@ -20,6 +22,29 @@ Documents.prototype = {
 
   bulkCreate: function(params, callback) {
     this.client.post('/engines/{engine}/document_types/{documentType}/documents/bulk_create_or_update.json', params, callback)
+  },
+
+  batchCreate: function(params, documents, batchSize, doneCallback){
+    if (!batchSize) {
+      doneCallback = batchSize
+      batchSize = 10
+    }
+
+    var tasks = []
+    while(documents.length) {
+      var batch = {
+        engine: params.engine,
+        documentType: params.documentType,
+        documents: documents.splice(0, batchSize)
+      };
+
+      var _this = this
+      tasks.push(function(callback){
+        _this.bulkCreate(batch, callback)
+      })
+    }
+
+    async.parallel(tasks, doneCallback);
   },
 
   update: function(params, callback) {

--- a/lib/documents.js
+++ b/lib/documents.js
@@ -30,22 +30,27 @@ Documents.prototype = {
       batchSize = 10
     }
 
-    var tasks = []
-    while(documents.length) {
-      var batch = {
-        engine: params.engine,
-        documentType: params.documentType,
-        documents: documents.splice(0, batchSize)
-      };
-
-      var _this = this
-      tasks.push(function(callback){
-        _this.bulkCreate(batch, callback)
-      })
+    var batches = []
+    for (var i=0; i < documents.length; i+=batchSize) {
+      batches.push(documents.slice(i, i+batchSize));
     }
+
+    var _this = this
+
+    var tasks = batches.map(function(batch){
+      var batchParams = {
+            engine: params.engine,
+            documentType: params.documentType,
+            documents: batch
+          }
+      return function(callback){
+        _this.bulkCreate(batchParams, callback)
+      }
+    })
 
     async.parallel(tasks, doneCallback);
   },
+
 
   update: function(params, callback) {
     this.client.put('/engines/{engine}/document_types/{documentType}/documents/{externalId}/update_fields.json', params, callback)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "node": ">= v0.8.0"
   },
   "dependencies": {
+    "async": "^0.9.0",
     "request": "~2.34.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This commit adds support for batched document creation. Currently bulk document creation is limited to a small number of document (around 100?). For our (Ember.js) use case we generate a larger set of documents (~3500) once a week and need to insert those in a batch.

I'm unhappy with the test for this, but I can't find _any_ example of using node-replay to response to the same url multiple times (which also has the side effect of there are no error case tests at all in this library).